### PR TITLE
Load contract artifacts from json files

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -37,8 +37,8 @@ class App extends Component {
     let Counter = {};
     let Wallet = {};
     try {
-      Counter = require('../../contracts/Counter.sol');
-      Wallet = require('../../contracts/Wallet.sol');
+      Counter = require('../../build/contracts/Counter.json');
+      Wallet = require('../../build/contracts/Wallet.json');
     } catch (e) {
       console.log(e);
     }


### PR DESCRIPTION
This commit is a hotfix to an issue in the hot loader (see https://github.com/zeppelinos/zeppelin-solidity-hot-loader/pull/5) that causes the contract to not be reloaded under certain circumstances. To bypass it, it simply loads the contract from the JSON artifact instead of from the Solidity source file, so webpack tracks the changes to the JSON file directly.