### PR TITLE
Update README to use CLI locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenZeppelin Starter Kit Tutorial
 
-An OpenZeppelin Starter Kit Tutorial containing React, OpenZeppelin SDK, OpenZeppelin Contracts, and Infura.
+An OpenZeppelin Starter Kit Tutorial containing React, OpenZeppelin CLI, OpenZeppelin Contracts, and Infura.
 
 This kit comes with everything you need to start using upgradeable Smart
 contracts inside your applications. It also includes all the configuration
@@ -10,10 +10,10 @@ In addition to the contents included in the [vanilla Starter Kit](https://github
 
 ## Requirements
 
-Install OpenZeppelin SDK, Ganache.
+Install Ganache.
 
 ```
-npm install ganache-cli@6.7.0 @openzeppelin/cli@2.5.3
+npm install ganache-cli@6.7.0
 ```
 
 ## Installation
@@ -21,7 +21,7 @@ npm install ganache-cli@6.7.0 @openzeppelin/cli@2.5.3
 Ensure you are in a new and empty directory, and run the `unpack` command with `tutorial` to create a starter project:
 
 ```javascript
-openzeppelin unpack tutorial
+npx @openzeppelin/cli unpack tutorial
 ```
 
 ## Run
@@ -36,13 +36,13 @@ In your original terminal window, at the top level of your folder, initialize th
 and follow the prompts:
 
 ```javascript
-openzeppelin init
+npx openzeppelin init
 ```
 
 After that compile the contracts:
 
 ```javascript
-openzeppelin compile
+npx openzeppelin compile
 ```
 
 In a new terminal window, in the `client` directory, run the React app:
@@ -56,23 +56,23 @@ npm run start
 
 You can interact directly with your smart contracts from the `openzeppelin` cli.
 
-`openzeppelin transfer`
+`npx openzeppelin transfer`
 
 send funds to a given address.
 
-`openzeppelin balance [address]`
+`npx openzeppelin balance [address]`
 
 query the ETH balance of the specified account, also supports ERC20s.
 
-`openzeppelin send-tx`
+`npx openzeppelin send-tx`
 
 sends a transaction to your contract and returns the events.
 
-`openzeppelin call`
+`npx openzeppelin call`
 
 execute a constant method and receive back the value.
 
-Type `openzeppelin` to see a complete list of availible commands.
+Type `npx openzeppelin` to see a complete list of availible commands.
 
 ## Test
 


### PR DESCRIPTION
Change to use CLI locally rather than install globally as the starter kit includes the CLI